### PR TITLE
Feat/patch user

### DIFF
--- a/src/app/features/user/application/dtos/user_dto.py
+++ b/src/app/features/user/application/dtos/user_dto.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
@@ -27,3 +29,20 @@ class UserCreate(BaseModel):
     password: str
     role: str = "user"
     is_active: bool = True
+
+
+class UserUpdate(BaseModel):
+    """
+    DTO for partial user updates.
+    All fields are optional - only provided fields will be updated.
+    Note: role and is_active are managed via admin-only endpoints.
+    """
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+    )
+
+    email: Optional[str] = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+

--- a/src/app/features/user/application/services/user_service.py
+++ b/src/app/features/user/application/services/user_service.py
@@ -1,8 +1,9 @@
 from src.app.features.user.application.use_cases.delete_user import DeleteUserUseCase
 from src.app.features.user.application.use_cases.get_user_by_id import GetUserByIdUseCase
 from src.app.features.user.application.use_cases.save_user import SaveUser
+from src.app.features.user.application.use_cases.update_user import UpdateUserUseCase
 from src.app.features.user.domain.repositories.user_repository import UserRepository
-from src.app.features.user.application.dtos.user_dto import UserCreate, UserResponse
+from src.app.features.user.application.dtos.user_dto import UserCreate, UserResponse, UserUpdate
 
 
 class UserService:
@@ -24,4 +25,9 @@ class UserService:
         use_case = DeleteUserUseCase(self.user_repository)
 
         return await use_case.execute(user_id)
+
+    async def update_user(self, user_id: str, user_update: UserUpdate) -> UserResponse:
+        use_case = UpdateUserUseCase(self.user_repository)
+
+        return await use_case.execute(user_id, user_update)
 

--- a/src/app/features/user/application/use_cases/update_user.py
+++ b/src/app/features/user/application/use_cases/update_user.py
@@ -1,0 +1,71 @@
+from uuid import UUID
+
+from src.app.features.user.application.dtos.user_dto import UserUpdate, UserResponse
+from src.app.features.user.application.dtos.user_dto_mapper import map_entity_to_dto_user
+from src.app.features.user.application.exceptions.user_exception import UserDoesNotExistException
+from src.app.features.user.domain.repositories.user_repository import UserRepository
+from src.app.features.user.domain.value_objects.email import Email
+from src.shared.domain.value_objects.entity_id import EntityId
+from src.shared.utils.log_util import log
+
+
+class UpdateUserUseCase:
+    """
+    Use case for partially updating a user's information.
+    """
+
+    def __init__(self, user_repository: UserRepository):
+        self.user_repository = user_repository
+
+    async def execute(self, user_id: str, user_update: UserUpdate) -> UserResponse:
+        """
+        Partially update a user by their ID.
+
+        Args:
+            user_id: The unique identifier of the user to update.
+            user_update: DTO containing the fields to update.
+
+        Returns:
+            UserResponse: The updated user's details.
+
+        Raises:
+            ValueError: If the user ID format is invalid.
+            UserDoesNotExistException: If the user does not exist.
+        """
+        try:
+            user_uuid = UUID(user_id)
+            user_entity_id = EntityId(user_uuid)
+
+            # Fetch existing user
+            existing_user = await self.user_repository.find_by_id(user_uuid)
+
+            if not existing_user:
+                log.warning(f"Cannot update user. User not found with ID: {user_id}")
+                raise UserDoesNotExistException(user_entity_id)
+
+            # Apply partial updates (only non-None fields)
+            if user_update.email is not None:
+                existing_user.email = Email(user_update.email)
+
+            if user_update.first_name is not None:
+                existing_user.first_name = user_update.first_name
+
+            if user_update.last_name is not None:
+                existing_user.last_name = user_update.last_name
+
+            # Persist changes
+            updated_user = await self.user_repository.update(existing_user)
+
+            log.info(f"User with ID {user_id} successfully updated.")
+
+            return map_entity_to_dto_user(updated_user)
+
+        except ValueError as e:
+            log.error(f"Invalid UUID format for user ID {user_id}: {e}")
+            raise ValueError(f"Invalid user ID format: {user_id}")
+        except UserDoesNotExistException:
+            raise
+        except Exception as e:
+            log.error(f"Unexpected error during update user for {user_id}: {str(e)}")
+            raise
+

--- a/src/app/features/user/presentation/web/routes/user_routes.py
+++ b/src/app/features/user/presentation/web/routes/user_routes.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from fastapi import APIRouter, status
 from fastapi.params import Depends
 
-from src.app.features.user.application.dtos.user_dto import UserResponse, UserCreate
+from src.app.features.user.application.dtos.user_dto import UserResponse, UserCreate, UserUpdate
 from src.app.features.user.application.services.user_service import UserService
 from src.app.features.user.presentation.web.dependencies import get_user_service
 
@@ -50,3 +50,23 @@ async def delete_user(user_id: UUID, user_service: UserService = Depends(get_use
         None: Returns 204 No Content on success.
     """
     await user_service.delete_user(str(user_id))
+
+
+@router.patch("/{user_id}", response_model=UserResponse, status_code=status.HTTP_200_OK)
+async def update_user(
+    user_id: UUID,
+    user_update: UserUpdate,
+    user_service: UserService = Depends(get_user_service)
+) -> UserResponse:
+    """
+    Partially update a user by their ID.
+
+    Args:
+        user_id (UUID): The user's unique identifier.
+        user_update (UserUpdate): The fields to update.
+
+    Returns:
+        UserResponse: The updated user's details.
+    """
+    return await user_service.update_user(str(user_id), user_update)
+


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

This pull request adds support for partial user updates (PATCH) to the user feature. It introduces a new `UserUpdate` DTO, a corresponding use case, and exposes a new PATCH endpoint in the user routes. The changes ensure only specified fields are updated, and admin-only fields remain protected.

**Partial user update support:**

* Added a new `UserUpdate` DTO in `user_dto.py` for partial user updates, making all fields optional and clarifying that `role` and `is_active` are admin-managed.
* Implemented `UpdateUserUseCase` in `update_user.py` to handle partial updates, including validation, error handling, and updating only provided fields.
* Updated `UserService` to include an `update_user` method that delegates to the new use case.
* Exposed a new PATCH `/users/{user_id}` endpoint in `user_routes.py` to allow partial updates via the API.

**Imports and wiring:**

* Updated imports in relevant files to include `UserUpdate` and the new use case, ensuring proper integration throughout the service and presentation layers. [[1]](diffhunk://#diff-dd650d769fbbe43ed17fbcf67c392543cf4553d7737618efe6a4b79e1918b05aR1-R2) [[2]](diffhunk://#diff-8164d0308919972e87f0dd1b36d1b4153af2bfa7687b4a21fc40034f927df936R4-R6) [[3]](diffhunk://#diff-e91805ac1c5ed561772b9da45903318729f6dd354afec1c608cb9f326cfa3c88L6-R6)

---

## 📸 Screenshots (if applicable)

<img width="1434" height="510" alt="Screenshot 2026-03-31 at 22 40 44" src="https://github.com/user-attachments/assets/514008f6-c40f-420c-8e8e-2447697c4745" />

---

## 🧠 Additional Context

Add any other context or screenshots about the pull request here.
