### PR TITLE
fix: c-02 no pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,96 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "e-commerce-api"
+version = "0.1.0"
+description = "Clean Architecture FastAPI e-commerce backend"
+requires-python = ">=3.11"
+authors = [
+    {name = "EndToEndLabCR Team", email = "team@endtoendlabcr.com"}
+]
+readme = "README.md"
+license = {text = "MIT"}
+
+# Production dependencies only
+dependencies = [
+    "fastapi==0.115.11",
+    "uvicorn==0.34.0",
+    "pydantic==2.10.6",
+    "email-validator==2.2.0",
+    "aiosmtplib==4.0.0",
+    "python-dotenv==1.0.1",
+    "SQLAlchemy==2.0.39",
+    "psycopg2-binary==2.9.10",
+    "gunicorn==23.0.0",
+    "backoff==2.2.1",
+    "pyaml-env==1.2.2",
+    "passlib[bcrypt]==1.7.4",
+    "pyjwt==2.10.1",
+    "python-jose[cryptography]==3.4.0",
+    "alembic==1.15.1",
+    "asyncpg==0.30.0",
+    "greenlet==3.3.0",
+]
+
+# Development dependencies (NOT installed in Docker production)
+[project.optional-dependencies]
+dev = [
+    "pytest==7.4.2",
+    "pytest-asyncio>=0.21.0",
+    "httpx>=0.24.1",  # For FastAPI TestClient
+    "mypy>=1.5.0",
+    "ruff>=0.1.0",
+]
+
+# Pytest configuration
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+python_files = ["test_*.py", "*_test.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = [
+    "-v",
+    "--strict-markers",
+    "--tb=short",
+]
+
+# Mypy configuration
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false  # Start lenient, tighten later
+ignore_missing_imports = true
+exclude = ["venv", "alembic"]
+
+# Ruff configuration (linter + formatter)
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+exclude = [
+    ".git",
+    "__pycache__",
+    "venv",
+    "alembic/versions",
+]
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "F",   # pyflakes
+    "I",   # isort (import sorting)
+    "N",   # pep8-naming
+    "W",   # pycodestyle warnings
+]
+ignore = [
+    "E501",  # line too long (handled by formatter)
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["src"]
+section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
+


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

This pull request adds a new `pyproject.toml` configuration file to the project, establishing the foundational build, dependency, and development tool settings for the e-commerce API. This file centralizes and standardizes project metadata, dependencies, and configuration for tools like pytest, mypy, and ruff.

Project setup and dependencies:

* Introduces the `[build-system]` and `[project]` sections, specifying build requirements, metadata, and core production dependencies for the FastAPI-based backend, including FastAPI, SQLAlchemy, and related libraries.
* Defines optional development dependencies under `[project.optional-dependencies]`, such as `pytest`, `mypy`, and `ruff`, to support testing, type checking, and linting during development.

Development tooling configuration:

* Adds configuration sections for pytest (`[tool.pytest.ini_options]`), mypy (`[tool.mypy]`), and ruff (`[tool.ruff]` and `[tool.ruff.lint]`), customizing their behavior for this codebase (e.g., test discovery rules, type checking strictness, linting rules and exclusions).

---

## 📸 Screenshots (if applicable)

Evidence that is working for local env as replacement of requirements.txt

<img width="2484" height="789" alt="Screenshot 2026-04-26 at 22 17 54" src="https://github.com/user-attachments/assets/ecc988ef-fb22-4506-8162-e84a84fcaa92" />

---

## 🧠 Additional Context

Add any other context or screenshots about the pull request here.

This is an addition to fix the critical issue (c-02) from the auditing documentation, implementing as a test.

<img width="648" height="485" alt="Screenshot 2026-04-26 at 22 21 28" src="https://github.com/user-attachments/assets/1820f78e-9b99-4f38-9f5d-68bca0181991" />

<img width="659" height="502" alt="Screenshot 2026-04-26 at 22 20 33" src="https://github.com/user-attachments/assets/9629cc17-458c-40b7-a137-5aa3d7476c54" />
