### PR TITLE
fix: adding missing UserResponse in user_service layer

### DIFF
--- a/src/app/features/user/application/services/user_service.py
+++ b/src/app/features/user/application/services/user_service.py
@@ -11,7 +11,7 @@ class UserService:
     def __init__(self, user_repository: UserRepository):
         self.user_repository = user_repository
 
-    async def get_user_by_id(self, user_id: str):
+    async def get_user_by_id(self, user_id: str) -> UserResponse:
         use_case = GetUserByIdUseCase(self.user_repository)
 
         return await use_case.execute(user_id)


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

Quick fix on user_service, missing explicit return type annotation UserResponse. (not in use by now)

---

## 📸 Screenshots (if applicable)

---

Before:
<img width="975" height="64" alt="Screenshot 2026-05-01 at 14 57 15" src="https://github.com/user-attachments/assets/7e428b6f-2cbc-4c26-ac2e-944fad8bfdb8" />

After:
<img width="986" height="101" alt="Screenshot 2026-05-01 at 14 57 33" src="https://github.com/user-attachments/assets/b1888cd8-f683-4b0f-931f-493b429ade3f" />


## 🧠 Additional Context

Using `mypy` in `--strict` mode I could check there was a function that does not explicitly return a type annotation.
